### PR TITLE
[Feature] - Add token issuance

### DIFF
--- a/lib/learn/accent_learn/presentation/accent_learn_screen.dart
+++ b/lib/learn/accent_learn/presentation/accent_learn_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 import 'dart:io' show Platform;
 
 
@@ -13,6 +12,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:saera/learn/accent_learn/presentation/widgets/accent_learn_background_image.dart';
 import 'package:saera/learn/accent_learn/presentation/widgets/accent_line_chart.dart';
 import 'package:saera/learn/accent_learn/presentation/widgets/audio_bar.dart';
+import 'package:saera/login/data/refresh_token.dart';
 import 'package:saera/style/color.dart';
 import 'package:saera/style/font.dart';
 import 'package:audioplayers/audioplayers.dart';
@@ -24,8 +24,6 @@ import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import 'package:http_parser/http_parser.dart';
-
 import '../../../login/data/authentication_manager.dart';
 
 
@@ -108,7 +106,7 @@ class _AccentPracticePageState extends State<AccentPracticePage> with TickerProv
   getExampleAccent() async {
 
     var url = Uri.parse('${serverHttp}/statements/${widget.id}');
-    final response = await http.get(url, headers: {'accept': 'application/json', "content-type": "application/json", "authorization" : "Bearer ${_authManager.getToken()}", "RefreshToken" : "Bearer ${_authManager.getRefreshToken()}" });
+    final response = await http.get(url, headers: {'accept': 'application/json', "content-type": "application/json", "authorization" : "Bearer ${_authManager.getToken()}" });
     if (response.statusCode == 200) {
       var body = jsonDecode(utf8.decode(response.bodyBytes));
 
@@ -132,6 +130,17 @@ class _AccentPracticePageState extends State<AccentPracticePage> with TickerProv
       y = List.from(body["pitch_y"]);
 
     }
+    else if(response.statusCode == 401){
+      String? before = _authManager.getToken();
+      await RefreshToken(context);
+
+      if(before != _authManager.getToken()){
+        getExampleAccent();
+      }
+    }
+    else{
+      print(response.body);
+    }
   }
 
 
@@ -140,7 +149,7 @@ class _AccentPracticePageState extends State<AccentPracticePage> with TickerProv
 
     var url = Uri.parse('${serverHttp}/statements/record/${widget.id}');
 
-    final response = await http.get(url, headers: {'accept': 'application/json', "content-type": "audio/wav", "authorization" : "Bearer ${_authManager.getToken()}", "RefreshToken" : "Bearer ${_authManager.getRefreshToken()}" });
+    final response = await http.get(url, headers: {'accept': 'application/json', "content-type": "audio/wav", "authorization" : "Bearer ${_authManager.getToken()}"});
 
     if (response.statusCode == 200) {
 

--- a/lib/login/data/cache_manager.dart
+++ b/lib/login/data/cache_manager.dart
@@ -13,6 +13,24 @@ mixin CacheManager {
     return true;
   }
 
+  Future<bool> saveName(String? name) async {
+    final box = GetStorage();
+    await box.write(CacheManagerKey.NAME.toString(), name);
+    return true;
+  }
+
+  Future<bool> saveEmail(String? email) async {
+    final box = GetStorage();
+    await box.write(CacheManagerKey.EMAIL.toString(), email);
+    return true;
+  }
+
+  Future<bool> savePhoto(String? photo) async {
+    final box = GetStorage();
+    await box.write(CacheManagerKey.PHOTO.toString(), photo);
+    return true;
+  }
+
   String? getToken() {
     final box = GetStorage();
     return box.read(CacheManagerKey.TOKEN.toString());
@@ -21,6 +39,21 @@ mixin CacheManager {
   String? getRefreshToken() {
     final box = GetStorage();
     return box.read(CacheManagerKey.REFRESHTOKEN.toString());
+  }
+
+  String? getName() {
+    final box = GetStorage();
+    return box.read(CacheManagerKey.NAME.toString());
+  }
+
+  String? getEmail() {
+    final box = GetStorage();
+    return box.read(CacheManagerKey.EMAIL.toString());
+  }
+
+  String? getPhoto() {
+    final box = GetStorage();
+    return box.read(CacheManagerKey.PHOTO.toString());
   }
 
   Future<void> removeToken() async {
@@ -36,5 +69,8 @@ mixin CacheManager {
 
 enum CacheManagerKey {
   TOKEN,
-  REFRESHTOKEN
+  REFRESHTOKEN,
+  NAME,
+  EMAIL,
+  PHOTO
 }

--- a/lib/login/data/refresh_token.dart
+++ b/lib/login/data/refresh_token.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:http/http.dart' as http;
+import 'package:saera/style/font.dart';
+import 'dart:convert';
+
+import '../../server.dart';
+import '../presentation/login_screen.dart';
+import 'authentication_manager.dart';
+
+
+bool check = false;
+
+Future<void> RefreshToken(BuildContext context) async {
+  final AuthenticationManager _authManager = Get.find();
+
+  var url = Uri.parse('$serverHttp/reissue-token');
+
+  final response = await http.get(url, headers: {'accept': 'application/json', "content-type": "application/json", "RefreshToken" : "Bearer ${_authManager.getRefreshToken()}" });
+
+  if (response.statusCode == 200) {
+    print('Response status: ${response.statusCode}');
+    print('Response body: ${jsonDecode(utf8.decode(response.bodyBytes))}');
+
+    var body = jsonDecode(response.body);
+
+    _authManager.saveToken(body["accessToken"]);
+    _authManager.saveRefreshToken(body["refreshToken"]);
+  }
+  else if(response.statusCode == 401){
+    if(context.mounted){
+      showDialog<String>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          title: const Text(
+            '로그인 만료',
+            style: TextStyles.large00TextStyle,
+          ),
+          content: const Text('로그인 유효 시간이 만료되었습니다. 다시 로그인해 주세요.'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => LoginPage()),
+                );
+              },
+              child: const Text(
+                  '로그인하기',
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+  else {
+    print(response.reasonPhrase);
+
+  }
+
+}

--- a/lib/login/presentation/login_screen.dart
+++ b/lib/login/presentation/login_screen.dart
@@ -39,7 +39,6 @@ class _LoginPageState extends State<LoginPage> {
       String refreshToken = body["refreshToken"];
 
       _authManager.login(accessToken, refreshToken);
-
       return true;
     }
     else{
@@ -60,6 +59,9 @@ class _LoginPageState extends State<LoginPage> {
       ).signIn();
 
       if (googleUser != null) {
+        _authManager.saveEmail(googleUser.email);
+        _authManager.saveName(googleUser.displayName);
+        _authManager.savePhoto(googleUser.photoUrl);
         getToken(googleUser.serverAuthCode);
 
         setState(() {
@@ -75,6 +77,9 @@ class _LoginPageState extends State<LoginPage> {
       ).signIn();
 
       if (googleUser != null) {
+        _authManager.saveEmail(googleUser.email);
+        _authManager.saveName(googleUser.displayName);
+        _authManager.savePhoto(googleUser.photoUrl);
         getToken(googleUser.serverAuthCode);
 
         setState(() {


### PR DESCRIPTION
## 🎀 Related Issues

#### close #54 

## 🤔 What Did You Do
- [x] 401 error 발생 시 refreshToken으로 토큰 재발급 가능 여부를 확인하여 토큰 재발급 받기
- [x] 토큰이 모두 만료된 경우 로그인 페이지로 이동하는 dialog를 띄우고 dialog 버튼 클릭 시 로그인 페이지로 이동할 수 있도록 구현


## 🛠 현재 플러터에서의 만료 토큰 확인 로직
API 호출시 401 error를 받으면 refresh token으로 토큰을 재발급 받을 수 있는지 확인 
1) 토큰을 재발급 받을 수 있다면 토큰을 재발급 받아 수행되지 못한 API 요청 함수 재실행 
2) refresh token이 만료되어 재발급 받을 수 없다면 사용자에게 토큰이 만료되었음을 안내하는 dialog를 띄운 후 사용자가 dialog의 로그인하기 버튼을 누르면 로그인 페이지로 이동

다른 로직 제안도 환영입니다. 더 좋은 방법이 있는지 저도 좀 더 고민해 볼게요.. (좀 더 다듬을 필요성이 있어 보이기는 해요..)
